### PR TITLE
Remove duplicate condition from if statement

### DIFF
--- a/counterpoint.py
+++ b/counterpoint.py
@@ -147,7 +147,7 @@ def bigleap(notebefore, note):
     if notebefore.isRest:
         return False
     interval=music21.interval.notesToChromatic(notebefore, note)
-    if interval==music21.interval.ChromaticInterval(6) or interval==music21.interval.ChromaticInterval(9) or interval == music21.interval.ChromaticInterval(10) or interval == music21.interval.ChromaticInterval(11) or interval == music21.interval.ChromaticInterval(6) or interval == music21.interval.ChromaticInterval(-6) or interval == music21.interval.ChromaticInterval(-8) or interval == music21.interval.ChromaticInterval(-9) or interval == music21.interval.ChromaticInterval(-10) or interval == music21.interval.ChromaticInterval(-11):
+    if interval==music21.interval.ChromaticInterval(6) or interval==music21.interval.ChromaticInterval(9) or interval == music21.interval.ChromaticInterval(10) or interval == music21.interval.ChromaticInterval(11) or interval == music21.interval.ChromaticInterval(-6) or interval == music21.interval.ChromaticInterval(-8) or interval == music21.interval.ChromaticInterval(-9) or interval == music21.interval.ChromaticInterval(-10) or interval == music21.interval.ChromaticInterval(-11):
         decision=True
     elif interval==music21.interval.ChromaticInterval(8):
         decision = 6


### PR DESCRIPTION
I spotted what looks like a duplicate:

```python
or interval == music21.interval.ChromaticInterval(6)
```

In an if statement predicate, and I wanted to double-check to make sure my understanding is correct before I propose any other changes to `bigleap`. There's still a big gap here in my understanding of the theory, so please do let me know if this isn't an appropriate change to make.