### PR TITLE
Remove non-pip package names from requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev"  # 3.5 development branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
 music21
 numpy
-random
-sys
-itertools
-math
-os
-pprint
-functools
-inspect


### PR DESCRIPTION
The `music21` and `numpy` packages are the only pip packages the project should be dependent on. This PR is a bit of an experiment to see if removing other namespace names fixes the build. 