### PR TITLE
Remove explicit comparison with True in if predicates

### DIFF
--- a/counterpoint/generator.py
+++ b/counterpoint/generator.py
@@ -293,7 +293,7 @@ class Generator (object):
                     f.write(' \n')
                 if Generator.bigleap(notebefore, note)==6 or Generator.bigleap(notebefore, note)==12 or Generator.bigleap(notebefore, note)==-12:
                     # print("special leaps detected:"+str(bigleap(notebefore, note)))
-                    if Generator.recover(Generator.bigleap(notebefore, note), note, noteafter)== False:
+                    if not Generator.recover(Generator.bigleap(notebefore, note), note, noteafter):
                         f.write('no recovery, break:'+str(c))
                         f.write(' \n')
 
@@ -310,11 +310,11 @@ class Generator (object):
                     flag=True
                     break
                 if Generator.bigleap(notebefore, note)==6 or Generator.bigleap(notebefore, note)==12 or Generator.bigleap(notebefore, note)==-12:
-                    if Generator.recover(Generator.bigleap(notebefore, note), note, noteafter)== False:
+                    if not Generator.recover(Generator.bigleap(notebefore, note), note, noteafter):
                         flag=True
                         break
 
-            if flag == False:
+            if not flag:
                 if Generator.is_same_note(plist[-2], plist[-1]):
                     f.write('Repeat note skipping lastnote:'+str(c))
                     f.write(' \n')
@@ -340,7 +340,7 @@ class Generator (object):
                 if Generator.bigleap(plist[-2], plist[-1])==True:
                     flag=True
 
-            if flag==False:
+            if not flag:
                 answer.append(plist)
         f.close()
 
@@ -595,14 +595,14 @@ class Generator (object):
                         f.write('paralleloctave skipping')
                         f.write(' \n')
                 if Generator.ifinharmonic(cf[o],note):
-                    if Generator.approleftstep(notebefore, note, noteafter)==False:
+                    if not Generator.approleftstep(notebefore, note, noteafter):
                         f.write('not approching by step')
                         f.write(' \n')
                 if Generator.bigleap(notebefore, note)==True:
                     f.write('Leap is too big skipping')
                     f.write(' \n')
                 if Generator.bigleap(notebefore, note)==6 or Generator.bigleap(notebefore, note)==12 or Generator.bigleap(notebefore, note)==-12:
-                    if Generator.recover(Generator.bigleap(notebefore, note), note, noteafter)== False:
+                    if not Generator.recover(Generator.bigleap(notebefore, note), note, noteafter):
                         f.write('no recovery, break')
                         f.write(' \n')
 
@@ -617,17 +617,17 @@ class Generator (object):
                         flag=True
                         break
                 if Generator.ifinharmonic(cf[o],note):
-                    if Generator.approleftstep(notebefore, note, noteafter)==False:
+                    if not Generator.approleftstep(notebefore, note, noteafter):
                         flag=True
                         break
                 if Generator.bigleap(notebefore, note)==True:
                     flag=True
                     break
                 if Generator.bigleap(notebefore, note)==6 or Generator.bigleap(notebefore, note)==12 or Generator.bigleap(notebefore, note)==-12:
-                    if Generator.recover(Generator.bigleap(notebefore, note), note, noteafter)== False:
+                    if not Generator.recover(Generator.bigleap(notebefore, note), note, noteafter):
                         flag=True
                         break
-            if flag == False:
+            if not flag:
                 if Generator.is_same_note(plist[-2], plist[-1]):
                     f.write('Repeat note skipping')
                     f.write(' \n')
@@ -638,7 +638,7 @@ class Generator (object):
                     f.write('paralleloctave skipping')
                     f.write(' \n')
                 if Generator.ifinharmonic(cf[-2],plist[-2]):
-                    if Generator.approleftstep(plist[-3], plist[-2], plist[-1])==False:
+                    if not Generator.approleftstep(plist[-3], plist[-2], plist[-1]):
                         f.write('not approching by step')
                         f.write(' \n')
                 if Generator.bigleap(plist[-2], plist[-1])==True:
@@ -655,14 +655,14 @@ class Generator (object):
                 if Generator.paralleloctave(cf[-2], plist[-3], cf[-1], plist[-1]):
                     flag=True
                 if Generator.ifinharmonic(cf[-2],plist[-2]):
-                    if Generator.approleftstep(plist[-3], plist[-2], plist[-1])==False:
+                    if not Generator.approleftstep(plist[-3], plist[-2], plist[-1]):
                         flag=True
                 if Generator.bigleap(plist[-2], plist[-1])==True:
                     flag=True
                 if Generator.bigleap(plist[-3], plist[-2])==True:
                     flag=True
 
-            if flag==False:
+            if not flag:
                 answer.append(plist)
 
 

--- a/counterpoint/generator.py
+++ b/counterpoint/generator.py
@@ -279,13 +279,13 @@ class Generator (object):
                 note=plist[i]
                 notebefore=plist[i-1]
                 noteafter=plist[i+1]
-                if Generator.is_same_note(notebefore, note) == True:
+                if Generator.is_same_note(notebefore, note):
                     f.write('Repeat note skipping:'+str(c))
                     f.write(' \n')
-                if Generator.parallelfifth(cf[i-1], notebefore, cf[i], note)==True:
+                if Generator.parallelfifth(cf[i-1], notebefore, cf[i], note):
                     f.write('parallelfifth skipping:'+str(c))
                     f.write(' \n')
-                if Generator.paralleloctave(cf[i-1], notebefore, cf[i], note)==True:
+                if Generator.paralleloctave(cf[i-1], notebefore, cf[i], note):
                     f.write('paralleloctave skipping:'+str(c))
                     f.write(' \n')
                 if Generator.bigleap(notebefore, note)==True:
@@ -297,13 +297,13 @@ class Generator (object):
                         f.write('no recovery, break:'+str(c))
                         f.write(' \n')
 
-                if Generator.is_same_note(notebefore, note) == True:
+                if Generator.is_same_note(notebefore, note):
                     flag=True
                     break
-                if Generator.parallelfifth(cf[i-1], notebefore, cf[i], note)==True:
+                if Generator.parallelfifth(cf[i-1], notebefore, cf[i], note):
                     flag=True
                     break
-                if Generator.paralleloctave(cf[i-1], notebefore, cf[i], note)==True:
+                if Generator.paralleloctave(cf[i-1], notebefore, cf[i], note):
                     flag=True
                     break
                 if Generator.bigleap(notebefore, note)==True:
@@ -315,13 +315,13 @@ class Generator (object):
                         break
 
             if flag == False:
-                if Generator.is_same_note(plist[-2], plist[-1]) == True:
+                if Generator.is_same_note(plist[-2], plist[-1]):
                     f.write('Repeat note skipping lastnote:'+str(c))
                     f.write(' \n')
-                if Generator.parallelfifth(cf[-2], plist[-2], cf[-1], plist[-1])==True:
+                if Generator.parallelfifth(cf[-2], plist[-2], cf[-1], plist[-1]):
                     f.write('parallelfifth skipping lastnote:'+str(c))
                     f.write(' \n')
-                if Generator.paralleloctave(cf[-2], plist[-2], cf[-1], plist[-1])==True:
+                if Generator.paralleloctave(cf[-2], plist[-2], cf[-1], plist[-1]):
                     f.write('paralleloctave skipping lastnote:'+str(c))
                     f.write(' \n')
                 if Generator.bigleap(plist[-2], plist[-1])==True:
@@ -331,11 +331,11 @@ class Generator (object):
                     f.write('no recovery, break lastnote:'+str(c))
                     f.write(' \n')
 
-                if Generator.is_same_note(plist[-2], plist[-1]) == True:
+                if Generator.is_same_note(plist[-2], plist[-1]):
                     flag=True
-                if Generator.parallelfifth(cf[-2], plist[-2], cf[-1], plist[-1])==True:
+                if Generator.parallelfifth(cf[-2], plist[-2], cf[-1], plist[-1]):
                     flag=True
-                if Generator.paralleloctave(cf[-2], plist[-2], cf[-1], plist[-1])==True:
+                if Generator.paralleloctave(cf[-2], plist[-2], cf[-1], plist[-1]):
                     flag=True
                 if Generator.bigleap(plist[-2], plist[-1])==True:
                     flag=True
@@ -584,17 +584,17 @@ class Generator (object):
                 noteafter=plist[i+1]
                 o=int(math.floor(i/2))
 
-                if Generator.is_same_note(notebefore, note) == True:
+                if Generator.is_same_note(notebefore, note):
                     f.write('Repeat note skipping')
                     f.write(' \n')
                 if i % 2 ==0:
-                    if Generator.parallelfifth(cf[o-1], notebefore2, cf[o], note)==True:
+                    if Generator.parallelfifth(cf[o-1], notebefore2, cf[o], note):
                         f.write('parallelfifth skipping')
                         f.write(' \n')
-                    if Generator.paralleloctave(cf[o-1], notebefore2, cf[o], note)==True:
+                    if Generator.paralleloctave(cf[o-1], notebefore2, cf[o], note):
                         f.write('paralleloctave skipping')
                         f.write(' \n')
-                if Generator.ifinharmonic(cf[o],note)==True:
+                if Generator.ifinharmonic(cf[o],note):
                     if Generator.approleftstep(notebefore, note, noteafter)==False:
                         f.write('not approching by step')
                         f.write(' \n')
@@ -606,17 +606,17 @@ class Generator (object):
                         f.write('no recovery, break')
                         f.write(' \n')
 
-                if Generator.is_same_note(notebefore, note) == True:
+                if Generator.is_same_note(notebefore, note):
                     flag=True
                     break
                 if i % 2 ==0:
-                    if Generator.parallelfifth(cf[o-1], notebefore2, cf[o], note)==True:
+                    if Generator.parallelfifth(cf[o-1], notebefore2, cf[o], note):
                         flag=True
                         break
-                    if Generator.paralleloctave(cf[o-1], notebefore2, cf[o], note)==True:
+                    if Generator.paralleloctave(cf[o-1], notebefore2, cf[o], note):
                         flag=True
                         break
-                if Generator.ifinharmonic(cf[o],note)==True:
+                if Generator.ifinharmonic(cf[o],note):
                     if Generator.approleftstep(notebefore, note, noteafter)==False:
                         flag=True
                         break
@@ -628,16 +628,16 @@ class Generator (object):
                         flag=True
                         break
             if flag == False:
-                if Generator.is_same_note(plist[-2], plist[-1]) == True:
+                if Generator.is_same_note(plist[-2], plist[-1]):
                     f.write('Repeat note skipping')
                     f.write(' \n')
-                if Generator.parallelfifth(cf[-2], plist[-3], cf[-1], plist[-1])==True:
+                if Generator.parallelfifth(cf[-2], plist[-3], cf[-1], plist[-1]):
                     f.write('parallelfifth skipping')
                     f.write(' \n')
-                if Generator.paralleloctave(cf[-2], plist[-3], cf[-1], plist[-1])==True:
+                if Generator.paralleloctave(cf[-2], plist[-3], cf[-1], plist[-1]):
                     f.write('paralleloctave skipping')
                     f.write(' \n')
-                if Generator.ifinharmonic(cf[-2],plist[-2])==True:
+                if Generator.ifinharmonic(cf[-2],plist[-2]):
                     if Generator.approleftstep(plist[-3], plist[-2], plist[-1])==False:
                         f.write('not approching by step')
                         f.write(' \n')
@@ -648,13 +648,13 @@ class Generator (object):
                     f.write('Leap is too big skipping')
                     f.write(' \n')
 
-                if Generator.is_same_note(plist[-2], plist[-1]) == True:
+                if Generator.is_same_note(plist[-2], plist[-1]):
                     flag=True
-                if Generator.parallelfifth(cf[-2], plist[-3], cf[-1], plist[-1])==True:
+                if Generator.parallelfifth(cf[-2], plist[-3], cf[-1], plist[-1]):
                     flag=True
-                if Generator.paralleloctave(cf[-2], plist[-3], cf[-1], plist[-1])==True:
+                if Generator.paralleloctave(cf[-2], plist[-3], cf[-1], plist[-1]):
                     flag=True
-                if Generator.ifinharmonic(cf[-2],plist[-2])==True:
+                if Generator.ifinharmonic(cf[-2],plist[-2]):
                     if Generator.approleftstep(plist[-3], plist[-2], plist[-1])==False:
                         flag=True
                 if Generator.bigleap(plist[-2], plist[-1])==True:


### PR DESCRIPTION
This PR just removes explicit comparison with `True` and `False` in if statement predicates to aid readability. Note that this excludes checks eliminated by #6.